### PR TITLE
Make short url endpoint

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.db.models import Model
 
+SHORT_URL_DOMAIN = "https://tier.app/"
+
 # Create your models here.
 class ShortUrl(Model):
     realUrl = models.CharField(max_length=200)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,0 +1,8 @@
+from .models import ShortUrl
+from rest_framework.serializers import ModelSerializer
+
+class ShortUrlSerializer(ModelSerializer):
+    class Meta:
+
+        model = ShortUrl
+        fields = ['realUrl']

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
+from .views import ShortUrlCreateView
 
 from . import views
 
 urlpatterns = [
-    path('', views.index, name='index'),
+    path('shortUrl/', ShortUrlCreateView.as_view(), name='short_url_create_view'),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -20,7 +20,15 @@ class ShortUrlCreateView(CreateAPIView):
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
-        return Response(generateShortUrlPath(10), 200)
+        # Generate the shortUrl
+        randomShortUrl = generateShortUrlPath(10)
+
+        # Create the ShortUrl object
+        newShortUrl = ShortUrl.objects.create(realUrl=request.data['realUrl'])
+        newShortUrl.shortUrl = randomShortUrl
+        newShortUrl.save()
+
+        return Response(newShortUrl.shortUrl, 200)
 
 # Generates a random string consisting of lower case letters
 # of length <length>

--- a/api/views.py
+++ b/api/views.py
@@ -1,6 +1,6 @@
 from django.http import HttpResponse
 
-from .models import ShortUrl
+from .models import ShortUrl, SHORT_URL_DOMAIN
 from .serializers import ShortUrlSerializer
 from rest_framework.generics import CreateAPIView
 from rest_framework.response import Response
@@ -28,7 +28,10 @@ class ShortUrlCreateView(CreateAPIView):
         newShortUrl.shortUrl = randomShortUrl
         newShortUrl.save()
 
-        return Response(newShortUrl.shortUrl, 200)
+        # Create the full URL with the domain 'tier.app'
+        fullShortUrl = SHORT_URL_DOMAIN + newShortUrl.shortUrl
+
+        return Response(fullShortUrl, 200)
 
 # Generates a random string consisting of lower case letters
 # of length <length>

--- a/api/views.py
+++ b/api/views.py
@@ -1,4 +1,21 @@
 from django.http import HttpResponse
 
+from .models import ShortUrl
+from .serializers import ShortUrlSerializer
+from rest_framework.generics import CreateAPIView
+from rest_framework.response import Response
+
 def index(request):
     return HttpResponse("Hello, world. You're at the api index.")
+
+class ShortUrlCreateView(CreateAPIView):
+
+    def post(self, request, format=None):
+
+        # Run serializer validation on the request arguments, and return an error message 
+        # if the user didn't provide all the expected arguments correctly
+        serializer = ShortUrlSerializer(data = request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        return Response(200)

--- a/api/views.py
+++ b/api/views.py
@@ -1,5 +1,3 @@
-from django.http import HttpResponse
-
 from .models import ShortUrl, SHORT_URL_DOMAIN
 from .serializers import ShortUrlSerializer
 from rest_framework.generics import CreateAPIView
@@ -35,7 +33,6 @@ class ShortUrlCreateView(CreateAPIView):
 # Credits: https://pynative.com/python-generate-random-string/
 def generateShortUrlPath(length):
 
-    # choose from all lowercase letter
     letters = string.ascii_lowercase
     result_str = ''.join(random.choice(letters) for i in range(length))
 

--- a/api/views.py
+++ b/api/views.py
@@ -5,6 +5,8 @@ from .serializers import ShortUrlSerializer
 from rest_framework.generics import CreateAPIView
 from rest_framework.response import Response
 
+import random, string 
+
 def index(request):
     return HttpResponse("Hello, world. You're at the api index.")
 
@@ -18,4 +20,15 @@ class ShortUrlCreateView(CreateAPIView):
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
-        return Response(200)
+        return Response(generateShortUrlPath(10), 200)
+
+# Generates a random string consisting of lower case letters
+# of length <length>
+# Credits: https://pynative.com/python-generate-random-string/
+def generateShortUrlPath(length):
+
+    # choose from all lowercase letter
+    letters = string.ascii_lowercase
+    result_str = ''.join(random.choice(letters) for i in range(length))
+
+    return result_str

--- a/api/views.py
+++ b/api/views.py
@@ -7,9 +7,6 @@ from rest_framework.response import Response
 
 import random, string 
 
-def index(request):
-    return HttpResponse("Hello, world. You're at the api index.")
-
 class ShortUrlCreateView(CreateAPIView):
 
     def post(self, request, format=None):


### PR DESCRIPTION
**Updates**
- Added a `POST api/shortURL` endpoint that takes a `realUrl` argument and returns a shorter url corresponding to it with the domain `tier.app`
- Removed the endpoint located at `localhost:8000/api/`

**Tech Updates:**
- Created a new file `api/serializers.py` with a seriallizer `ShortUrlSerializer` to help with validating the `POST api/shortUrl` endpoint
- Created a helper function `generateShortUrlPath()` that generates a short url path of a specified integer length
- Created a constant `SHORT_URL_DOMAIN` in `api/models.py`