### PR TITLE
Quick Fixes for `POST api/shortUrl` endpoint 

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -26,7 +26,7 @@ class ShortUrlCreateView(CreateAPIView):
         # Create the full URL with the domain 'tier.app'
         fullShortUrl = SHORT_URL_DOMAIN + newShortUrl.shortUrl
 
-        return Response(fullShortUrl, 200)
+        return Response({'shortUrl': fullShortUrl}, 200)
 
 # Generates a random string consisting of lower case letters
 # of length <length>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 asgiref==3.5.2
 Django==4.1.2
+django-cors-headers==3.13.0
 djangorestframework==3.14.0
 pytz==2022.4
 sqlparse==0.4.3

--- a/tierbackendforwebsite/settings.py
+++ b/tierbackendforwebsite/settings.py
@@ -38,7 +38,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'api.apps.ApiConfig',
-    'rest_framework'
+    'rest_framework',
+    "corsheaders",
 ]
 
 MIDDLEWARE = [
@@ -49,6 +50,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "corsheaders.middleware.CorsMiddleware",
 ]
 
 ROOT_URLCONF = 'tierbackendforwebsite.urls'
@@ -123,3 +125,7 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:3000",
+]


### PR DESCRIPTION
**Updates**
- Made some quick fixes to the `POST api/shortUrl` endpoint from pull request #1 
   - Added CORS headers to the django project, so the frontend could make requests to this server without getting cross origin errors
      - Updated the server to explicitly accept requests originating from the frontend (i.e. `localhost:3000`)
   - Updated `POST api/shortUrl` to return the response in JSON format, rather than plain text format

**Tech Updates:**
- Added `django-cors-headers==3.13.0` to `requirements.txt`